### PR TITLE
Shorten flow run name

### DIFF
--- a/prefect_langchain/plugins.py
+++ b/prefect_langchain/plugins.py
@@ -4,7 +4,6 @@ from contextlib import ContextDecorator
 from functools import wraps
 from typing import Callable
 
-import pendulum
 from langchain.llms.base import BaseLLM
 from langchain.schema import LLMResult
 from prefect import Flow


### PR DESCRIPTION
Minor suggestion to shorten flow run name since the timestamp is already a part of the metadata Prefect captures